### PR TITLE
[ORDER] 주문 조회 및 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.github.smartlogismsa:common-module:v0.0.7'
+    implementation 'com.github.smartlogismsa:common-module:v0.0.9'
     implementation 'mysql:mysql-connector-java:8.0.33'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.github.smartlogismsa:common-module:0.0.6'
+    implementation 'com.github.smartlogismsa:common-module:v0.0.7'
     implementation 'mysql:mysql-connector-java:8.0.33'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'orderService'
+rootProject.name = 'orderservice'

--- a/src/main/java/com/smartlogis/orderservice/application/service/OrderService.java
+++ b/src/main/java/com/smartlogis/orderservice/application/service/OrderService.java
@@ -86,15 +86,13 @@ public class OrderService {
 	}
 
 	@Transactional
-	public OrderResponse deleteOrder(UUID orderId) {
+	public void deleteOrder(UUID orderId) {
 		Order order = orderRepository.findByIdAndDeletedAtIsNull(orderId)
 			.orElseThrow(() -> new OrderNotFoundException(OrderMessageCode.ORDER_NOT_FOUND));
 
 		order.delete();
 
-		Order savedOrder = orderRepository.save(order);
-
-		return OrderResponse.from(savedOrder);
+		orderRepository.save(order);
 	}
 
 	@Transactional(readOnly = true)
@@ -106,7 +104,7 @@ public class OrderService {
 	}
 
 	@Transactional(readOnly = true)
-	public PageResponse<OrderResponse> getOrderByCompany(UUID receiptCompanyId, PageRequest pageRequest) {
+	public PageResponse<OrderResponse> getOrdersByCompany(UUID receiptCompanyId, PageRequest pageRequest) {
 		Sort.Direction direction = Sort.Direction.fromString(
 			pageRequest.getDirection() != null ? pageRequest.getDirection() : "DESC"
 		);

--- a/src/main/java/com/smartlogis/orderservice/application/service/OrderService.java
+++ b/src/main/java/com/smartlogis/orderservice/application/service/OrderService.java
@@ -3,9 +3,14 @@ package com.smartlogis.orderservice.application.service;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.smartlogis.common.presentation.dto.PageRequest;
+import com.smartlogis.common.presentation.dto.PageResponse;
 import com.smartlogis.orderservice.domain.entity.Order;
 import com.smartlogis.orderservice.domain.entity.OrderItem;
 import com.smartlogis.orderservice.domain.event.OrderCanceledEvent;
@@ -78,5 +83,43 @@ public class OrderService {
 		orderEventPublisher.publishOrderCanceled(event);
 
 		return OrderResponse.from(savedOrder);
+	}
+
+	@Transactional
+	public OrderResponse deleteOrder(UUID orderId) {
+		Order order = orderRepository.findByIdAndDeletedAtIsNull(orderId)
+			.orElseThrow(() -> new OrderNotFoundException(OrderMessageCode.ORDER_NOT_FOUND));
+
+		order.delete();
+
+		Order savedOrder = orderRepository.save(order);
+
+		return OrderResponse.from(savedOrder);
+	}
+
+	@Transactional(readOnly = true)
+	public OrderResponse getOrder(UUID orderId) {
+		Order order = orderRepository.findByIdAndDeletedAtIsNull(orderId)
+			.orElseThrow(() -> new OrderNotFoundException(OrderMessageCode.ORDER_NOT_FOUND));
+
+		return OrderResponse.from(order);
+	}
+
+	@Transactional(readOnly = true)
+	public PageResponse<OrderResponse> getOrderByCompany(UUID receiptCompanyId, PageRequest pageRequest) {
+		Sort.Direction direction = Sort.Direction.fromString(
+			pageRequest.getDirection() != null ? pageRequest.getDirection() : "DESC"
+		);
+		String sortBy = pageRequest.getSortBy() != null ? pageRequest.getSortBy() : "createdAt";
+
+		Pageable pageable = org.springframework.data.domain.PageRequest.of(
+			pageRequest.getPage(),
+			pageRequest.getSize(),
+			Sort.by(direction, sortBy)
+		);
+
+		Page<Order> orders = orderRepository.findByReceiptCompanyIdAndDeletedAtIsNull(receiptCompanyId, pageable);
+
+		return PageResponse.from(orders.map(OrderResponse::from));
 	}
 }

--- a/src/main/java/com/smartlogis/orderservice/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/smartlogis/orderservice/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.smartlogis.orderservice.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI openAPI(@Value("${openapi.service.url}") String url) {
+		return new OpenAPI()
+			.servers(List.of(new Server().url(url)))
+			.components(new Components().addSecuritySchemes("Bearer", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")))
+			.addSecurityItem(new SecurityRequirement().addList("Bearer"))
+			.info(new Info().title("주문 서비스")
+				.description("Order API"));
+	}
+}
+

--- a/src/main/java/com/smartlogis/orderservice/interfaces/controller/OrderController.java
+++ b/src/main/java/com/smartlogis/orderservice/interfaces/controller/OrderController.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.smartlogis.common.presentation.ApiResponse;
+import com.smartlogis.common.presentation.dto.PageRequest;
+import com.smartlogis.common.presentation.dto.PageResponse;
 import com.smartlogis.orderservice.application.service.OrderService;
 import com.smartlogis.orderservice.interfaces.dto.request.CreateOrderRequest;
 import com.smartlogis.orderservice.interfaces.dto.response.OrderResponse;
@@ -34,10 +38,33 @@ public class OrderController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.successWithDataOnly(response));
 	}
 
-	@DeleteMapping("/{orderId}")
+	@DeleteMapping("/cancel/{orderId}")
 	@PreAuthorize("hasAnyRole('MASTER', 'COMPANY_MANAGER')")
 	public ResponseEntity<ApiResponse<OrderResponse>> cancelOrder(@PathVariable UUID orderId) {
 		OrderResponse response = orderService.cancelOrder(orderId);
 		return ResponseEntity.ok(ApiResponse.successWithDataOnly(response));
+	}
+
+	@GetMapping("/{orderId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<OrderResponse>> getOrder(@PathVariable UUID orderId) {
+		OrderResponse response = orderService.getOrder(orderId);
+		return ResponseEntity.ok(ApiResponse.successWithDataOnly(response));
+	}
+
+	@GetMapping("/company/{receiptCompanyId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<PageResponse<OrderResponse>>> getOrdersByCompany(
+		@PathVariable UUID receiptCompanyId,
+		@ModelAttribute PageRequest pageRequest) {
+		PageResponse<OrderResponse> response = orderService.getOrdersByCompany(receiptCompanyId, pageRequest);
+		return ResponseEntity.ok(ApiResponse.successWithDataOnly(response));
+	}
+
+	@DeleteMapping("/{orderId}")
+	@PreAuthorize("hasAnyRole('MASTER')")
+	public ResponseEntity<ApiResponse<Void>> deleteOrder(@PathVariable UUID orderId) {
+		orderService.deleteOrder(orderId);
+		return ResponseEntity.ok(ApiResponse.successWithDataOnly(null));
 	}
 }

--- a/src/main/java/com/smartlogis/orderservice/interfaces/controller/OrderController.java
+++ b/src/main/java/com/smartlogis/orderservice/interfaces/controller/OrderController.java
@@ -21,49 +21,87 @@ import com.smartlogis.orderservice.application.service.OrderService;
 import com.smartlogis.orderservice.interfaces.dto.request.CreateOrderRequest;
 import com.smartlogis.orderservice.interfaces.dto.response.OrderResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/v1/orders")
 @RequiredArgsConstructor
+@Tag(name = "Order API", description = "주문 관련 API")
 public class OrderController {
 
 	private final OrderService orderService;
 
 	@PostMapping
 	@PreAuthorize("hasAnyRole('MASTER', 'COMPANY_MANAGER')")
-	public ResponseEntity<ApiResponse<OrderResponse>> createOrder(@Valid @RequestBody CreateOrderRequest request) {
+	@Operation(
+		summary = "주문 생성",
+		description = "새로운 주문을 생성합니다. 재고 확인 후 주문이 생성되며, OrderCreatedEvent가 발행됩니다."
+	)
+	public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
+		@Valid @RequestBody CreateOrderRequest request) {
 		OrderResponse response = orderService.createOrder(request);
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.successWithDataOnly(response));
 	}
 
 	@DeleteMapping("/cancel/{orderId}")
 	@PreAuthorize("hasAnyRole('MASTER', 'COMPANY_MANAGER')")
-	public ResponseEntity<ApiResponse<OrderResponse>> cancelOrder(@PathVariable UUID orderId) {
+	@Operation(
+		summary = "주문 취소",
+		description = "PENDING 상태의 주문만 취소 가능합니다. 취소 시 OrderCanceledEvent가 발행됩니다."
+	)
+	public ResponseEntity<ApiResponse<OrderResponse>> cancelOrder(
+		@PathVariable
+		@Parameter(description = "주문 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+		UUID orderId) {
 		OrderResponse response = orderService.cancelOrder(orderId);
 		return ResponseEntity.ok(ApiResponse.successWithDataOnly(response));
 	}
 
 	@GetMapping("/{orderId}")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<OrderResponse>> getOrder(@PathVariable UUID orderId) {
+	@Operation(
+		summary = "주문 단건 조회",
+		description = "삭제되지 않은 주문을 ID로 조회합니다."
+	)
+	public ResponseEntity<ApiResponse<OrderResponse>> getOrder(
+		@PathVariable
+		@Parameter(description = "주문 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+		UUID orderId) {
 		OrderResponse response = orderService.getOrder(orderId);
 		return ResponseEntity.ok(ApiResponse.successWithDataOnly(response));
 	}
 
 	@GetMapping("/company/{receiptCompanyId}")
 	@PreAuthorize("isAuthenticated()")
+	@Operation(
+		summary = "업체별 주문 목록 조회",
+		description = "특정 업체의 주문 목록을 페이지네이션하여 조회합니다."
+	)
 	public ResponseEntity<ApiResponse<PageResponse<OrderResponse>>> getOrdersByCompany(
-		@PathVariable UUID receiptCompanyId,
-		@ModelAttribute PageRequest pageRequest) {
+		@PathVariable
+		@Parameter(description = "업체 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+		UUID receiptCompanyId,
+		@ModelAttribute
+		@Parameter(description = "페이지네이션 요청")
+		PageRequest pageRequest) {
 		PageResponse<OrderResponse> response = orderService.getOrdersByCompany(receiptCompanyId, pageRequest);
 		return ResponseEntity.ok(ApiResponse.successWithDataOnly(response));
 	}
 
 	@DeleteMapping("/{orderId}")
 	@PreAuthorize("hasAnyRole('MASTER')")
-	public ResponseEntity<ApiResponse<Void>> deleteOrder(@PathVariable UUID orderId) {
+	@Operation(
+		summary = "주문 삭제 (논리적 삭제)",
+		description = "주문을 논리적으로 삭제합니다. 삭제된 주문은 조회되지 않습니다."
+	)
+	public ResponseEntity<ApiResponse<Void>> deleteOrder(
+		@PathVariable
+		@Parameter(description = "주문 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+		UUID orderId) {
 		orderService.deleteOrder(orderId);
 		return ResponseEntity.ok(ApiResponse.successWithDataOnly(null));
 	}

--- a/src/main/java/com/smartlogis/orderservice/interfaces/controller/OrderController.java
+++ b/src/main/java/com/smartlogis/orderservice/interfaces/controller/OrderController.java
@@ -8,6 +8,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,7 +48,7 @@ public class OrderController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.successWithDataOnly(response));
 	}
 
-	@DeleteMapping("/cancel/{orderId}")
+	@PatchMapping("/cancel/{orderId}")
 	@PreAuthorize("hasAnyRole('MASTER', 'COMPANY_MANAGER')")
 	@Operation(
 		summary = "주문 취소",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,25 @@ spring:
         service-id: config-server
       uri: ${CONFIG_SERVER_URL}
 
+springdoc:
+  version: '1.0.0'
+  api-docs:
+    path: /v3/api-docs
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    operations-sorter: alpha
+    tags-sorter: alpha
+    path: /api-docs.html
+    disable-swagger-default-url: true
+    doc-expansion: full
+  paths-to-match:
+    - /**
+
+openapi:
+  service:
+    url: http://localhost:3000
+
 eureka:
   instance:
     prefer-ip-address: false

--- a/src/test/java/com/smartlogis/orderservice/application/service/OrderServiceTest.java
+++ b/src/test/java/com/smartlogis/orderservice/application/service/OrderServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import com.smartlogis.common.presentation.dto.PageRequest;
 import com.smartlogis.common.presentation.dto.PageResponse;
 import com.smartlogis.orderservice.TestMessageResolver;
 import com.smartlogis.orderservice.domain.entity.Order;
@@ -320,15 +321,19 @@ class OrderServiceTest {
 			OrderItem.create(null, productId2, 5)
 		));
 
-		Page<Order> mockPage = new PageImpl<>(List.of(order1, order2));
+		Page<Order> mockPage = new PageImpl<>(
+			List.of(order1, order2),
+			org.springframework.data.domain.PageRequest.of(0, 10),
+			2
+		);
 
 		given(orderRepository.findByReceiptCompanyIdAndDeletedAtIsNull(
 			eq(companyId),
 			any(Pageable.class)))
 			.willReturn(mockPage);
 
-		com.smartlogis.common.presentation.dto.PageRequest pageRequest =
-			new com.smartlogis.common.presentation.dto.PageRequest(0, 10, "createdAt", "DESC");
+		PageRequest pageRequest =
+			new PageRequest(0, 10, "createdAt", "DESC");
 
 		// when
 		PageResponse<OrderResponse> response = orderService.getOrdersByCompany(companyId, pageRequest);
@@ -356,8 +361,8 @@ class OrderServiceTest {
 			any(Pageable.class)))
 			.willReturn(emptyPage);
 
-		com.smartlogis.common.presentation.dto.PageRequest pageRequest =
-			new com.smartlogis.common.presentation.dto.PageRequest(0, 10, "createdAt", "DESC");
+		PageRequest pageRequest =
+			new PageRequest(0, 10, "createdAt", "DESC");
 
 		// when
 		PageResponse<OrderResponse> response = orderService.getOrdersByCompany(companyId, pageRequest);

--- a/src/test/java/com/smartlogis/orderservice/application/service/OrderServiceTest.java
+++ b/src/test/java/com/smartlogis/orderservice/application/service/OrderServiceTest.java
@@ -15,7 +15,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import com.smartlogis.common.presentation.dto.PageResponse;
 import com.smartlogis.orderservice.TestMessageResolver;
 import com.smartlogis.orderservice.domain.entity.Order;
 import com.smartlogis.orderservice.domain.entity.OrderItem;
@@ -211,6 +215,157 @@ class OrderServiceTest {
 			.save(any(Order.class));
 		then(orderEventPublisher).should(never())
 			.publishOrderCanceled(any(OrderCanceledEvent.class));
+	}
+
+	@Test
+	@DisplayName("존재하는 주문을 논리적 삭제 성공")
+	void deleteOrder_Success_WhenOrderExists() {
+		// given
+		UUID orderId = UUID.randomUUID();
+		Order mockOrder = Order.create(receiptCompanyId, "테스트", List.of(
+			OrderItem.create(null, productId1, 10)
+		));
+
+		given(orderRepository.findByIdAndDeletedAtIsNull(orderId))
+			.willReturn(Optional.of(mockOrder));
+
+		// when
+		orderService.deleteOrder(orderId);
+
+		// then
+		then(orderRepository).should(times(1))
+			.findByIdAndDeletedAtIsNull(orderId);
+		then(orderRepository).should(times(1))
+			.save(any(Order.class));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 주문 삭제 시 OrderNotFoundException 발생")
+	void deleteOrder_ThrowsException_WhenOrderNotFound() {
+		// given
+		UUID orderId = UUID.randomUUID();
+
+		given(orderRepository.findByIdAndDeletedAtIsNull(orderId))
+			.willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> orderService.deleteOrder(orderId))
+			.isInstanceOf(OrderNotFoundException.class);
+
+		then(orderRepository).should(never())
+			.save(any(Order.class));
+	}
+
+	@Test
+	@DisplayName("이미 삭제된 주문 삭제 시 OrderNotFoundException 발생")
+	void deleteOrder_ThrowsException_WhenAlreadyDeleted() {
+		// given
+		UUID orderId = UUID.randomUUID();
+
+		given(orderRepository.findByIdAndDeletedAtIsNull(orderId))
+			.willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> orderService.deleteOrder(orderId))
+			.isInstanceOf(OrderNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("존재하는 주문 단건 조회 성공")
+	void getOrder_Success_WhenOrderExists() {
+		// given
+		UUID orderId = UUID.randomUUID();
+		Order mockOrder = Order.create(receiptCompanyId, "테스트", List.of(
+			OrderItem.create(null, productId1, 10)
+		));
+
+		given(orderRepository.findByIdAndDeletedAtIsNull(orderId))
+			.willReturn(Optional.of(mockOrder));
+
+		// when
+		OrderResponse response = orderService.getOrder(orderId);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.getReceiptCompanyId()).isEqualTo(receiptCompanyId);
+
+		then(orderRepository).should(times(1))
+			.findByIdAndDeletedAtIsNull(orderId);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 주문 조회 시 OrderNotFoundException 발생")
+	void getOrder_ThrowsException_WhenOrderNotFound() {
+		// given
+		UUID orderId = UUID.randomUUID();
+
+		given(orderRepository.findByIdAndDeletedAtIsNull(orderId))
+			.willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> orderService.getOrder(orderId))
+			.isInstanceOf(OrderNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("업체별 주문 목록 조회 성공")
+	void getOrdersByCompany_Success() {
+		// given
+		UUID companyId = UUID.randomUUID();
+
+		Order order1 = Order.create(companyId, "주문1", List.of(
+			OrderItem.create(null, productId1, 10)
+		));
+		Order order2 = Order.create(companyId, "주문2", List.of(
+			OrderItem.create(null, productId2, 5)
+		));
+
+		Page<Order> mockPage = new PageImpl<>(List.of(order1, order2));
+
+		given(orderRepository.findByReceiptCompanyIdAndDeletedAtIsNull(
+			eq(companyId),
+			any(Pageable.class)))
+			.willReturn(mockPage);
+
+		com.smartlogis.common.presentation.dto.PageRequest pageRequest =
+			new com.smartlogis.common.presentation.dto.PageRequest(0, 10, "createdAt", "DESC");
+
+		// when
+		PageResponse<OrderResponse> response = orderService.getOrdersByCompany(companyId, pageRequest);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.page()).isEqualTo(0);
+		assertThat(response.size()).isEqualTo(10);
+		assertThat(response.total()).isEqualTo(2);
+
+		then(orderRepository).should(times(1))
+			.findByReceiptCompanyIdAndDeletedAtIsNull(eq(companyId), any(Pageable.class));
+	}
+
+	@Test
+	@DisplayName("업체에 주문이 없을 때 빈 리스트 반환")
+	void getOrdersByCompany_ReturnsEmptyList_WhenNoOrders() {
+		// given
+		UUID companyId = UUID.randomUUID();
+		Page<Order> emptyPage = new PageImpl<>(List.of());
+
+		given(orderRepository.findByReceiptCompanyIdAndDeletedAtIsNull(
+			eq(companyId),
+			any(Pageable.class)))
+			.willReturn(emptyPage);
+
+		com.smartlogis.common.presentation.dto.PageRequest pageRequest =
+			new com.smartlogis.common.presentation.dto.PageRequest(0, 10, "createdAt", "DESC");
+
+		// when
+		PageResponse<OrderResponse> response = orderService.getOrdersByCompany(companyId, pageRequest);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.content()).isEmpty();
+		assertThat(response.total()).isEqualTo(0);
 	}
 
 	private OrderItemRequest createOrderItemRequest(UUID productId, int quantity) {

--- a/src/test/java/com/smartlogis/orderservice/domain/entity/OrderTest.java
+++ b/src/test/java/com/smartlogis/orderservice/domain/entity/OrderTest.java
@@ -3,6 +3,7 @@ package com.smartlogis.orderservice.domain.entity;
 import static org.assertj.core.api.Assertions.*;
 
 import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -76,6 +77,36 @@ class OrderTest {
 		// when & then
 		assertThatThrownBy(() -> order.cancel())
 			.isInstanceOf(OrderCannotBeCanceledException.class);
+	}
+
+	@Test
+	@DisplayName("주문을 논리적 삭제할 수 있다")
+	void delete_Success() {
+		// given
+		Order order = Order.create(receiptCompanyId, "긴급 배송", orderItems);
+
+		// when
+		order.delete();
+
+		// then
+		assertThat(order.getDeletedAt()).isNotNull();
+		assertThat(order.getDeletedBy()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("삭제된 주문은 deletedAt과 deletedBy가 설정된다")
+	void delete_SetsDeletedAtAndDeletedBy() {
+		// given
+		Order order = Order.create(receiptCompanyId, "긴급 배송", orderItems);
+		LocalDateTime beforeDelete = LocalDateTime.now();
+
+		// when
+		order.delete();
+
+		// then
+		assertThat(order.getDeletedAt()).isNotNull();
+		assertThat(order.getDeletedAt()).isAfterOrEqualTo(beforeDelete);
+		assertThat(order.getDeletedBy()).isNotNull();
 	}
 
 	private void setOrderStatus(Order order, OrderStatus status) {

--- a/src/test/java/com/smartlogis/orderservice/interfaces/controller/OrderControllerTest.java
+++ b/src/test/java/com/smartlogis/orderservice/interfaces/controller/OrderControllerTest.java
@@ -19,6 +19,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.http.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartlogis.common.presentation.dto.PageRequest;
+import com.smartlogis.common.presentation.dto.PageResponse;
 import com.smartlogis.orderservice.TestMessageResolver;
 import com.smartlogis.orderservice.application.service.OrderService;
 import com.smartlogis.orderservice.interfaces.dto.request.CreateOrderRequest;
@@ -160,7 +162,7 @@ class OrderControllerTest {
 			.willReturn(cancelResponse);
 
 		// when & then
-		mockMvc.perform(delete("/v1/orders/{orderId}", orderId))
+		mockMvc.perform(delete("/v1/orders/cancel/{orderId}", orderId))
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.id").value(orderId.toString()))
@@ -169,5 +171,105 @@ class OrderControllerTest {
 
 		then(orderService).should(times(1))
 			.cancelOrder(any(UUID.class));
+	}
+
+	@Test
+	@DisplayName("주문 단건 조회 성공 시 200 OK 반환")
+	void getOrder_Success() throws Exception {
+		// given
+		UUID orderId = UUID.randomUUID();
+		UUID receiptCompanyId = UUID.randomUUID();
+
+		OrderResponse response = OrderResponse.builder()
+			.id(orderId)
+			.receiptCompanyId(receiptCompanyId)
+			.requestDetails("긴급 배송 요청")
+			.orderItems(List.of())
+			.build();
+
+		given(orderService.getOrder(any(UUID.class)))
+			.willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/v1/orders/{orderId}", orderId))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(orderId.toString()))
+			.andExpect(jsonPath("$.data.receiptCompanyId").value(receiptCompanyId.toString()))
+			.andExpect(jsonPath("$.data.requestDetails").value("긴급 배송 요청"));
+
+		then(orderService).should(times(1))
+			.getOrder(any(UUID.class));
+	}
+
+	@Test
+	@DisplayName("업체별 주문 목록 조회 성공 시 200 OK 반환")
+	void getOrdersByCompany_Success() throws Exception {
+		// given
+		UUID receiptCompanyId = UUID.randomUUID();
+
+		OrderResponse order1 = OrderResponse.builder()
+			.id(UUID.randomUUID())
+			.receiptCompanyId(receiptCompanyId)
+			.requestDetails("주문1")
+			.orderItems(List.of())
+			.build();
+
+		OrderResponse order2 = OrderResponse.builder()
+			.id(UUID.randomUUID())
+			.receiptCompanyId(receiptCompanyId)
+			.requestDetails("주문2")
+			.orderItems(List.of())
+			.build();
+
+		PageResponse<OrderResponse> pageResponse =
+			new PageResponse<>(
+				List.of(order1, order2),
+				0,
+				10,
+				2L
+			);
+
+		given(orderService.getOrdersByCompany(
+			any(UUID.class),
+			any(PageRequest.class)))
+			.willReturn(pageResponse);
+
+		// when & then
+		mockMvc.perform(get("/v1/orders/company/{receiptCompanyId}", receiptCompanyId)
+				.param("page", "0")
+				.param("size", "10")
+				.param("sortBy", "createdAt")
+				.param("direction", "DESC"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.content.length()").value(2))
+			.andExpect(jsonPath("$.data.page").value(0))
+			.andExpect(jsonPath("$.data.size").value(10))
+			.andExpect(jsonPath("$.data.total").value(2));
+
+		then(orderService).should(times(1))
+			.getOrdersByCompany(
+				any(UUID.class),
+				any(PageRequest.class));
+	}
+
+	@Test
+	@DisplayName("주문 삭제 성공 시 200 OK 반환")
+	void deleteOrder_Success() throws Exception {
+		// given
+		UUID orderId = UUID.randomUUID();
+
+		willDoNothing().given(orderService)
+			.deleteOrder(any(UUID.class));
+
+		// when & then
+		mockMvc.perform(delete("/v1/orders/{orderId}", orderId))
+			.andDo(print())
+			.andExpect(status().isOk());
+
+		then(orderService).should(times(1))
+			.deleteOrder(any(UUID.class));
 	}
 }


### PR DESCRIPTION
## 📝 요약 (Summary)
주문 조회 (단건/목록) 및 삭제 (논리적 삭제) 기능을 구현했습니다.


## 🛠️ 작업 내용 (Details)
### Service Layer (OrderService)
- `deleteOrder(UUID orderId)` : 주문 논리적 삭제 (deleted_at, deleted_by 설정)
- `getOrder(UUID orderId)` : 주문 단건 조회 (삭제되지 않은 주문만)
- `getOrdersByCompany(UUID receiptCompanyId, PageRequest pageRequest)` : 업체별 주문 목록 조회

### Controller Layer (OrderController)
- `DELETE /v1/orders/{orderId}` : 주문 삭제
- `GET /v1/orders/{orderId}` : 주문 단건 조회
- `GET /v1/orders/company/{receiptCompanyId}` : 업체별 주문 목록 조회
- Swagger 문서화


## 🔀 변경 유형 (Change Type)

- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)
- `DELETE /v1/orders/{orderId}` : 주문 삭제
- `GET /v1/orders/{orderId}` : 주문 단건 조회
- `GET /v1/orders/company/{receiptCompanyId}` : 업체별 주문 목록 조회
- `OrderServiceTest` : deleteOrder, getOrder, getOrdersByCompany 단위 테스트
- `OrderControllerTest` : API 엔드포인트 통합 테스트
